### PR TITLE
Added alpha component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ serde = { version = "1.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 version-sync = "0.9"
+test-case = "2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,71 @@
 //! A Rust library for parsing, serializing, and operating on hex colors.
+//!
+//! The [`HexColor`] contains the 3 RGB components and an optional alpha component.
+//!
+//! Suppoted parsing of 3, 6, 4 and 8 character hex codes. When converting to a string only the longer 6 and 8 character codes are produced.
+//!
+//! 3 and 6 character codes set [alpha] to `None`.
+//! Same for converting to string: if [alpha] is `None` then a 6 character code is produced.
+//! You can also make a color with no alpha by using [`HexColor::rgb()`] method.
+//!
+//! [alpha]: HexColor::a
+//!
+//! ```
+//! # use hex_color::HexColor;
+//! # use hex_color::ParseHexColorError;
+//! # fn main() -> Result<(), ParseHexColorError> {
+//! assert_eq!(HexColor::rgb(0x11, 0x22, 0x33), "#112233".parse::<HexColor>()?);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Alpha component
+//!
+//! For 4 and 8 character codes alpha is set to `Some(value)`.
+//! When converting to string such color will produce an 8 character code.
+//! You can construct a color with alpha by using [`HexColor::rgba()`] The last argument in `rgba()` always sets
+//! alpha to `Some(a)`.
+//!
+//! ```
+//! # use hex_color::HexColor;
+//! # use hex_color::ParseHexColorError;
+//! # fn main() -> Result<(), ParseHexColorError> {
+//! assert_eq!("#000f".parse::<HexColor>()?, HexColor::rgba(0, 0, 0, 255));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Scalar scaling and adding.
+//!
+//! You can add, substract, multiply and divide a color. This applies the same operation to all components.
+//!
+//! ```
+//! # use hex_color::HexColor;
+//! assert_eq!(
+//!     HexColor::rgb(0, 2, 7) + 3,
+//!     HexColor::rgb(3, 5, 10),
+//! );
+//! assert_eq!(
+//!     HexColor::rgba(0, 2, 7, 6) + 3,
+//!     HexColor::rgba(3, 5, 10, 9),
+//! );
+//! ```
+//!
+//! As you can see if there is no alpha then it stays as `None`.
+//!
+//! # Operatons with 2 colors
+//!
+//! Corresponding components are added/multiplied/etc together. Following is a table explaining how alpha is calculated:
+//!
+//!
+//! ```
+//! # use hex_color::HexColor;
+//! let blue = HexColor::rgba(0, 5, 0xff, 0x11);
+//! let red = HexColor::rgba(0xff, 5, 0, 0xee);
+//! let purple_green = HexColor::rgba(0xff, 10, 0xff, 0xff);
+//!
+//! assert_eq!(blue + red, purple_green);
+//! ```
 
 #![doc(html_root_url = "https://docs.rs/hex_color/1.0.0")]
 #![warn(missing_docs)]
@@ -18,7 +85,7 @@ use lazy_static::lazy_static;
 
 use regex::Regex;
 
-/// An RGB color represented in hexadecimal.
+/// An RGB(A) color represented in hexadecimal.
 ///
 /// # Examples
 ///
@@ -26,15 +93,15 @@ use regex::Regex;
 ///
 /// *Note*: The parsing of hex colors is somewhat lenient: it does not need to
 /// be prefixed with `#`, is trimmed before being parsed, is case insensitive,
-/// and supports shorthand three-character representations as well as the more
-/// common six.
+/// and supports shorthand 3 and 4 character representations as well as the more
+/// common 6 and 8.
 ///
 /// ```
 /// use hex_color::HexColor;
 /// # use hex_color::ParseHexColorError;
 ///
 /// # fn main() -> Result<(), ParseHexColorError> {
-/// let black = HexColor { r: 0, g: 0, b: 0 };
+/// let black = HexColor { r: 0, g: 0, b: 0, a: None};
 /// let gray = HexColor::new(127, 127, 127);
 /// let white: HexColor = "#FFFFFF".parse()?;
 /// # Ok(())
@@ -69,14 +136,26 @@ use regex::Regex;
 /// # }
 /// ```
 ///
+/// ## Transparency calculations
+///
+/// | Left    | Right   | Result                                  |
+/// |---------|---------|-----------------------------------------|
+/// | `Some`  | `Some`  | Calculated the same way as other fields |
+/// | _(any)_ | `None`  | Same as left's alpha (could be `None`)  |
+/// | `None`  | _(any)_ | `None`                                  |
+///
 /// Convert a hex color to a string:
 ///
 /// ```
 /// use hex_color::HexColor;
 ///
-/// let gray = HexColor { r: 127, g: 127, b: 127 };
-///
+/// // no alpha
+/// let gray = HexColor { r: 127, g: 127, b: 127, a: None };
 /// assert_eq!(gray.to_string(), "#7F7F7F");
+///
+/// // with alpha
+/// let gray = HexColor { r: 127, g: 127, b: 127, a: Some(255) };
+/// assert_eq!(gray.to_string(), "#7F7F7FFF");
 /// ```
 #[derive(Copy, Clone, Debug, Default, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct HexColor {
@@ -86,86 +165,204 @@ pub struct HexColor {
     pub g: u8,
     /// The blue component of the color.
     pub b: u8,
+    /// Optional alpha component used in 4 and 8 character hex colors.
+    /// If set to `None` then `to_string()` will not add any opacity.
+    /// When parsing something like `"#fff"` This field will be set to `None` since there is no information about the alpha.
+    /// `"#ffff"` however will set `a` to `Some(255)`.
+    ///
+    /// ```
+    /// use hex_color::HexColor;
+    /// # use hex_color::ParseHexColorError;
+    ///
+    /// # fn main() -> Result<(), ParseHexColorError> {
+    /// let color = HexColor::rgba(1,2,3,4);
+    /// let repr = String::from("#01020304");
+    ///
+    /// assert_eq!(repr.parse::<HexColor>()?, color);
+    /// assert_eq!(repr, color.to_string());
+    /// # Ok(())
+    /// # }
+    pub a: Option<u8>,
 }
 
 impl HexColor {
-    /// Creates a new hex color with the given red, green, and blue components.
+    /// Since the addition of alpha this function is deprecated.
+    /// It's left in for backwards compatibility, but may be removed or changed in the future.
+    /// Use [`rgb()`] or [`rgba()`] instead.
+    /// Currently `new()` acts the same as [`rgb()`].
+    ///
+    /// [`rgb()`]: HexColor::rgb()
+    /// [`rgba()`]: HexColor::rgba()
+    #[deprecated]
+    pub const fn new(r: u8, g: u8, b: u8) -> Self {
+        Self::rgb(r, g, b)
+    }
+
+    /// Creates a new hex color only with red, green and blue components.
+    /// Alpha is set to `None`.
     ///
     /// # Examples
     ///
     /// ```
     /// use hex_color::HexColor;
     ///
-    /// let red = HexColor::new(255, 0, 0);
+    /// let red = HexColor::rgb(255, 0, 0);
+    /// assert_eq!(red.a, None);
     /// ```
-    pub const fn new(r: u8, g: u8, b: u8) -> Self {
-        HexColor { r, g, b }
+    pub const fn rgb(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b, a: None }
+    }
+
+    /// Creates a new color with red, green, blue and alpha components.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hex_color::HexColor;
+    ///
+    /// let red = HexColor::rgba(255, 0, 0, 255);
+    /// assert_eq!(red.a, Some(255));
+    /// ```
+    pub const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Self {
+            r,
+            g,
+            b,
+            a: Some(a),
+        }
     }
 }
 
 impl Display for HexColor {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "#{:02X?}{:02X?}{:02X?}", self.r, self.g, self.b)
+        match self.a {
+            None => write!(f, "#{:02X?}{:02X?}{:02X?}", self.r, self.g, self.b),
+            Some(a) => write!(
+                f,
+                "#{:02X?}{:02X?}{:02X?}{:02X?}",
+                self.r, self.g, self.b, a
+            ),
+        }
     }
 }
 
 lazy_static! {
-    static ref HEX_COLOR_3_REGEX: Regex =
-        Regex::new("(?i)^#?(?P<r>[\\da-f])(?P<g>[\\da-f])(?P<b>[\\da-f])$").unwrap();
-    static ref HEX_COLOR_6_REGEX: Regex =
-        Regex::new("(?i)^#?(?P<r>[\\da-f]{2})(?P<g>[\\da-f]{2})(?P<b>[\\da-f]{2})$").unwrap();
+    static ref HEX_COLOR: Regex = Regex::new(r"(?i-u)^#?(?P<la>[[:xdigit:]]{8})|(?P<l>[[:xdigit:]]{6})|(?P<sa>[[:xdigit:]]{4})|(?P<s>[[:xdigit:]]{3})$").unwrap();
+    static ref LA_COLOR: Regex = Regex::new(r"^([[:xdigit:]]{2})([[:xdigit:]]{2})([[:xdigit:]]{2})([[:xdigit:]]{2})$").unwrap();
+    static ref L_COLOR: Regex =  Regex::new(r"^([[:xdigit:]]{2})([[:xdigit:]]{2})([[:xdigit:]]{2})$").unwrap();
+    static ref SA_COLOR: Regex = Regex::new(r"^([[:xdigit:]]{1})([[:xdigit:]]{1})([[:xdigit:]]{1})([[:xdigit:]]{1})$").unwrap();
+    static ref S_COLOR: Regex =  Regex::new(r"^([[:xdigit:]]{1})([[:xdigit:]]{1})([[:xdigit:]]{1})$").unwrap();
+
 }
 
 impl FromStr for HexColor {
     type Err = ParseHexColorError;
-
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim();
-        // TODO: Find a better way of doing this?
-        let (r, g, b) = if let Some(c) = HEX_COLOR_3_REGEX.captures(s) {
-            (
-                c.name("r").unwrap().as_str().repeat(2),
-                c.name("g").unwrap().as_str().repeat(2),
-                c.name("b").unwrap().as_str().repeat(2),
-            )
-        } else if let Some(c) = HEX_COLOR_6_REGEX.captures(s) {
-            (
-                c.name("r").unwrap().as_str().to_string(),
-                c.name("g").unwrap().as_str().to_string(),
-                c.name("b").unwrap().as_str().to_string(),
-            )
-        } else {
-            return Err(ParseHexColorError(s.to_string()));
+        let err = Err(ParseHexColorError(s.to_owned()));
+
+        let c = match HEX_COLOR.captures(s.trim()) {
+            Some(c) => c,
+            None => return err,
         };
-        Ok(HexColor {
-            r: u8::from_str_radix(&r, 16).unwrap(),
-            g: u8::from_str_radix(&g, 16).unwrap(),
-            b: u8::from_str_radix(&b, 16).unwrap(),
-        })
+
+        let which = |c: char| -> usize {
+            match c {
+                'r' => 1,
+                'g' => 2,
+                'b' => 3,
+                'a' => 4,
+                _ => unreachable!("Never call with {}", c),
+            }
+        };
+
+        let get_long = |c: &regex::Captures, component: char| -> Result<u8, ParseHexColorError> {
+            Ok(<u8>::from_str_radix(
+                c.get(which(component))
+                    .ok_or(ParseHexColorError(s.to_string()))?
+                    .as_str(),
+                16,
+            )
+            .or(Err(ParseHexColorError(s.to_string())))?)
+        };
+
+        let get_short = |c: &regex::Captures, component: char| -> Result<u8, ParseHexColorError> {
+            Ok(<u8>::from_str_radix(
+                &c.get(which(component))
+                    .ok_or(ParseHexColorError(s.to_string()))?
+                    .as_str()
+                    .repeat(2),
+                16,
+            )
+            .or(Err(ParseHexColorError(s.to_string())))?)
+        };
+
+        if let Some(c) = c.name("la") {
+            let c = LA_COLOR
+                .captures(c.as_str())
+                .ok_or(ParseHexColorError(s.to_string()))?;
+            return Ok(Self {
+                r: get_long(&c, 'r')?,
+                g: get_long(&c, 'g')?,
+                b: get_long(&c, 'b')?,
+                a: Some(get_long(&c, 'a')?),
+            });
+        }
+
+        if let Some(c) = c.name("l") {
+            let c = L_COLOR
+                .captures(c.as_str())
+                .ok_or(ParseHexColorError(s.to_string()))?;
+            return Ok(Self {
+                r: get_long(&c, 'r')?,
+                g: get_long(&c, 'g')?,
+                b: get_long(&c, 'b')?,
+                a: None,
+            });
+        }
+
+        if let Some(c) = c.name("sa") {
+            let c = SA_COLOR
+                .captures(c.as_str())
+                .ok_or(ParseHexColorError(s.to_string()))?;
+            return Ok(Self {
+                r: get_short(&c, 'r')?,
+                g: get_short(&c, 'g')?,
+                b: get_short(&c, 'b')?,
+                a: Some(get_short(&c, 'a')?),
+            });
+        }
+
+        if let Some(c) = c.name("s") {
+            let c = S_COLOR
+                .captures(c.as_str())
+                .ok_or(ParseHexColorError(s.to_string()))?;
+            return Ok(Self {
+                r: get_short(&c, 'r')?,
+                g: get_short(&c, 'g')?,
+                b: get_short(&c, 'b')?,
+                a: None,
+            });
+        }
+
+        err
     }
 }
 
 /// An error which can be returned when parsing a hex color.
 ///
 /// This error is used as the error type for the [`FromStr`] implementation for
-/// [`HexColor`].
+/// [`HexColor`]. The error contains a value that was not parsed.
 ///
-/// # Examples
-///
-/// The following code would panic from a `ParseHexColorError` as `"#GHIJKL"` is
-/// not a valid hex color:
-///
-/// ```should_panic
-/// use hex_color::HexColor;
-/// # use hex_color::ParseHexColorError;
-///
-/// # fn main() -> Result<(), ParseHexColorError> {
-/// let invalid_color = "#GHIJKL".parse::<HexColor>()?;
-/// # Ok(())
-/// # }
 /// ```
+/// # use hex_color::{HexColor, ParseHexColorError};
+/// assert_eq!("#GHIJKL".parse::<HexColor>(), ParseHexColorError("#GHIJKL"));
+/// ```
+///
+/// # Panics
+///
+/// [`FromStr`] never panics.
 #[derive(Debug)]
-pub struct ParseHexColorError(String);
+pub struct ParseHexColorError(pub String);
 
 impl Display for ParseHexColorError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -179,43 +376,114 @@ impl Error for ParseHexColorError {}
 mod tests {
     use super::*;
 
-    const BLACK: HexColor = HexColor::new(0, 0, 0);
-    const GRAY: HexColor = HexColor::new(127, 127, 127);
-    const WHITE: HexColor = HexColor::new(255, 255, 255);
+    extern crate test_case;
+    use test_case::test_case;
 
-    const BLACK_STR: &'static str = "#000000";
-    const GRAY_STR: &'static str = "#7F7F7F";
-    const WHITE_STR: &'static str = "#FFFFFF";
+    #[cfg(test)]
+    #[test_case("fff", "s"; "short no alpha")]
+    #[test_case("ffff", "sa"; "short with alpha")]
+    #[test_case("ffFFff", "l"; "long no alpha")]
+    #[test_case("ffFFffFF", "la"; "long with alpha")]
+    fn regex_categorize_color(s: &str, n: &str) {
+        HEX_COLOR
+            .captures(s)
+            .expect("Should be captured")
+            .name(n)
+            .expect(&format!(
+                "hex = {}, len = {}; Captured as an incorrect group (expected {})",
+                s,
+                s.len(),
+                n
+            ));
+    }
 
-    #[test]
-    fn from_str_accuracy() -> Result<(), ParseHexColorError> {
-        assert_eq!(BLACK_STR.parse::<HexColor>()?, BLACK);
-        assert_eq!(GRAY_STR.parse::<HexColor>()?, GRAY);
-        assert_eq!(WHITE_STR.parse::<HexColor>()?, WHITE);
+    #[test_case(0x00, 0x00, 0x00, "#000000"; "Black")]
+    #[test_case(0x13, 0x69, 0x46, "#136946"; "Should parse correctly")]
+    #[test_case(0xff, 0xff, 0xff, "#ffffff"; "White")]
+    fn to_and_from_string_no_alpha(r: u8, g: u8, b: u8, s: &str) -> Result<(), ParseHexColorError> {
+        let hex_color = HexColor::rgb(r, g, b);
+
+        assert_eq!(s.parse::<HexColor>()?, hex_color);
+        assert_eq!(hex_color.to_string().to_lowercase(), s.to_lowercase());
 
         Ok(())
     }
 
-    #[test]
-    fn from_str() -> Result<(), ParseHexColorError> {
-        assert_eq!("fff".parse::<HexColor>()?, WHITE);
-        assert_eq!("FFF".parse::<HexColor>()?, WHITE);
-        assert_eq!("#fff".parse::<HexColor>()?, WHITE);
-        assert_eq!("#FFF".parse::<HexColor>()?, WHITE);
-        assert_eq!("ffffff".parse::<HexColor>()?, WHITE);
-        assert_eq!("FFFFFF".parse::<HexColor>()?, WHITE);
-        assert_eq!("#ffffff".parse::<HexColor>()?, WHITE);
-        assert_eq!("#FFFFFF".parse::<HexColor>()?, WHITE);
-
+    #[test_case(HexColor{r: 0xff, g: 0x11, b: 0x55, a: None}, "#f15"; "Short no alpha")]
+    fn supported_formats(color: HexColor, repr: &str) -> Result<(), ParseHexColorError> {
+        assert_eq!(color, repr.parse::<HexColor>()?);
         Ok(())
     }
 
     #[test]
-    fn to_string() -> Result<(), ParseHexColorError> {
-        assert_eq!(BLACK.to_string(), BLACK_STR);
-        assert_eq!(GRAY.to_string(), GRAY_STR);
-        assert_eq!(WHITE.to_string(), WHITE_STR);
+    fn any_format() -> Result<(), ParseHexColorError> {
+        let mut bitset = BitSet::new();
+        loop {
+            let mut color = HexColor::rgb(255, 255, 255);
+            let mut repr: String = "fff".into();
+            // Bitset is used here to implement an iteration over all possible types of hex codes:
+            // e.g. capitalised, with and without the "#", etc.
+            //
+            // Adding more checks requires just adding another `if bitset.next()` and running some code instead of
+            // performing multiple steps like adding another for loop, not forgetting to permute a value
+            // or making a list of all possible values like `["#fff", "#FFF", ...]`.
 
-        Ok(())
+            if bitset.next() {
+                repr += "f";
+                color.a = Some(255);
+            }
+
+            if bitset.next() {
+                repr = repr.to_uppercase();
+            }
+
+            if bitset.next() {
+                repr = repr.repeat(2);
+            }
+
+            if bitset.next() {
+                repr = "#".to_owned() + &repr;
+            }
+
+            if bitset.end() {
+                break;
+            }
+
+            assert_eq!(repr.parse::<HexColor>()?, color, "from value: {}", repr);
+        }
+        return Ok(());
+
+        /// Used in this test to go over every possible combination of hex code qualities, e.g. capitalised, with "#", has alpha.
+        struct BitSet {
+            bits: i128,
+            ptr: usize,
+        }
+        impl BitSet {
+            /// Creates a new bitset.
+            fn new() -> Self {
+                Self { bits: 0, ptr: 0 }
+            }
+
+            /// Yields the next bit from a bitset as bool.
+            fn next(&mut self) -> bool {
+                let bit = (self.bits >> self.ptr) & 1;
+                self.ptr += 1;
+                bit != 0
+            }
+
+            /// Finishes a bitset iteration. Increments bitset value and resets its pointer.
+            /// Used to indicate that all properties have been read and now we should check if
+            /// there is an "overflow".
+            ///
+            /// # Return value
+            ///
+            /// Returns true if internal pointer points to a 1.
+            fn end(&mut self) -> bool {
+                let end = self.next();
+                self.ptr = 0;
+                self.bits += 1;
+                end
+            }
+        }
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -44,16 +44,27 @@ macro_rules! forward_ref_op_assign {
     };
 }
 
+fn alpha_op(self_a: Option<u8>, other_a: Option<u8>, op: impl FnOnce(u8, u8) -> u8) -> Option<u8> {
+    if let None = other_a {
+        return self_a;
+    }
+    match self_a {
+        Some(a) => Some(op(a, other_a.expect("Should never panic."))),
+        None => None,
+    }
+}
+
 impl Add for HexColor {
     type Output = HexColor;
 
     #[inline]
     fn add(self, other: Self) -> Self::Output {
-        HexColor::new(
-            u8::saturating_add(self.r, other.r),
-            u8::saturating_add(self.g, other.g),
-            u8::saturating_add(self.b, other.b),
-        )
+        HexColor {
+            r: u8::saturating_add(self.r, other.r),
+            g: u8::saturating_add(self.g, other.g),
+            b: u8::saturating_add(self.b, other.b),
+            a: alpha_op(self.a, other.a, |a, o| u8::saturating_add(a, o)),
+        }
     }
 }
 
@@ -75,11 +86,16 @@ macro_rules! add_impl {
 
             #[inline]
             fn add(self, other: $t) -> Self::Output {
-                HexColor::new(
-                    (self.r as $t + other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                    (self.g as $t + other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                    (self.b as $t + other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                )
+                let calc = |s: u8| (s as $t + other).clamp(u8::MIN as $t, u8::MAX as $t) as u8;
+                HexColor{
+                    r: calc(self.r),
+                    g: calc(self.g),
+                    b: calc(self.b),
+                    a: match self.a {
+                        Some(a) => Some(calc(a)),
+                        None => None
+                    },
+                }
             }
         }
 
@@ -113,11 +129,12 @@ impl Sub for HexColor {
 
     #[inline]
     fn sub(self, other: Self) -> Self::Output {
-        HexColor::new(
-            u8::saturating_sub(self.r, other.r),
-            u8::saturating_sub(self.g, other.g),
-            u8::saturating_sub(self.b, other.b),
-        )
+        HexColor {
+            r: u8::saturating_sub(self.r, other.r),
+            g: u8::saturating_sub(self.g, other.g),
+            b: u8::saturating_sub(self.b, other.b),
+            a: alpha_op(self.a, other.a, |a, o| u8::saturating_sub(a, o)),
+        }
     }
 }
 
@@ -139,11 +156,16 @@ macro_rules! sub_impl {
 
             #[inline]
             fn sub(self, other: $t) -> Self::Output {
-                HexColor::new(
-                    (self.r as $t - other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                    (self.g as $t - other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                    (self.b as $t - other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                )
+                let calc = |s|(s as $t - other).clamp(u8::MIN as $t, u8::MAX as $t) as u8;
+                HexColor{
+                    r: calc(self.r),
+                    g: calc(self.g),
+                    b: calc(self.b),
+                    a: match self.a {
+                        Some(a) => Some(calc(a)),
+                        None => None
+                    }
+                }
             }
         }
 
@@ -179,11 +201,16 @@ macro_rules! mul_impl {
 
             #[inline]
             fn mul(self, other: $t) -> Self::Output {
-                HexColor::new(
-                    (self.r as $t * other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                    (self.g as $t * other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                    (self.b as $t * other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                )
+               let calc = |s|(s as $t * other).clamp(u8::MIN as $t, u8::MAX as $t) as u8;
+                HexColor{
+                    r: calc(self.r),
+                    g: calc(self.g),
+                    b: calc(self.b),
+                    a: match self.a {
+                        Some(a) => Some(calc(a)),
+                        None => None
+                    }
+                }
             }
         }
 
@@ -219,11 +246,16 @@ macro_rules! div_impl {
 
             #[inline]
             fn div(self, other: $t) -> Self::Output {
-                HexColor::new(
-                    (self.r as $t / other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                    (self.g as $t / other).clamp(u8::MIN as $t, u8::MAX as $t) as u8,
-                    (self.b as $t / other).clamp(u8::MIN as $t, u8::MAX as $t) as u8
-                )
+                let calc = |s|(s as $t / other).clamp(u8::MIN as $t, u8::MAX as $t) as u8;
+                HexColor{
+                    r: calc(self.r),
+                    g: calc(self.g),
+                    b: calc(self.b),
+                    a: match self.a {
+                        Some(a) => Some(calc(a)),
+                        None => None
+                    }
+                }
             }
         }
 
@@ -246,10 +278,21 @@ div_impl! { usize u8 u16 u32 u64 u128 isize i8 i16 i32 i64 i128 f32 f64 }
 mod tests {
     use super::*;
 
-    const ZERO: HexColor = HexColor::new(0, 0, 0);
-    const ONE: HexColor = HexColor::new(1, 1, 1);
-    const TWO: HexColor = HexColor::new(2, 2, 2);
-    const MAX: HexColor = HexColor::new(255, 255, 255);
+    extern crate test_case;
+    use test_case::test_case;
+
+    const ZERO: HexColor = HexColor::rgb(0, 0, 0);
+    const ONE: HexColor = HexColor::rgb(1, 1, 1);
+    const TWO: HexColor = HexColor::rgb(2, 2, 2);
+    const MAX: HexColor = HexColor::rgb(255, 255, 255);
+
+    #[test_case(Some(2),   Some(3),   Some(2+3); "Calculate")]
+    #[test_case(Some(100), None,      Some(100); "Same as left")]
+    #[test_case(None,      None,      None;      "None")]
+    #[test_case(None,      Some(100), None;      "Always None")]
+    fn alha_op_no_panic(a: Option<u8>, b: Option<u8>, r: Option<u8>) {
+        assert_eq!(alpha_op(a, b, |a, b| a + b), r);
+    }
 
     #[test]
     fn add_hex() {


### PR DESCRIPTION
| Q                         | A
| ------------------------- | -----
| Fixed Issues?             | Fixes #2, Implements #1
| Patch: Bug fix?           | No
| Minor: New feature?       | Added Alpha to `HexColor` as `Option<u8>`
| Major: Breaking change?   | Suggest to deprecate `HexColor::new() `
| Any dependency changes?   | Added dev dep. `test_case`

# Why use `Option<u8>` as alpha?

Here are the other options:
1) Use a default value
2) Make a separate type

If we assume some default value then this wont pass:
```rust
let color = "#ff00ff"
assert_eq!(HexColor::from_str(color).to_str(), color);
```
Making a separate type only makes sense if the user wants to enforce alpha to be present or absent. Which can be done with an `Option` already.

Using an `enum`? That is already kind of there. An `Option` is an `enum` so if you want to match on it you can.

And putting everything in one place gives the convenience of enabling and disabling alpha without making any copies.

# The actuall changes:

- Refactored some tests with [`#[test_case()]`](https://crates.io/crates/test-case) (Added as dev dependency.)
- Updated all docs to include transparency.
- Added transparency calculations to [src/ops.rs](https://github.com/m-kuzmin/hex_color/blob/main/src/ops.rs)
- Also removed a possibility of a panic in `HexColor::from_str()`.
- **_Deprecated_** `HexColor::new()`, added `HexColor::rgb()` and `HexColor::rgba()`.

**Note:** Test coverage and docs have to be checked since I am only 90% sure that i have checked everything.
There is no version bumb.