### PR TITLE
optimization: use a single rng.next_u32() instead of three rng.gen()

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -7,6 +7,11 @@ use crate::HexColor;
 impl Distribution<HexColor> for Standard {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> HexColor {
-        HexColor::rgb(rng.gen(), rng.gen(), rng.gen())
+        let u = rng.next_u32();
+        HexColor::rgb(
+            (u & 0xff) as u8,
+            ((u >> 8) & 0xff) as u8,
+            ((u >> 16) & 0xff) as u8,
+        )
     }
 }


### PR DESCRIPTION
<!-- Before making a PR, please read my contributing guidelines https://github.com/seancroach/.github/blob/main/CONTRIBUTING.md -->

| Q                         | A <!--(Can use an emoji 👍) -->
| ------------------------- | -----
| Fixed Issues?             | Nope
| Patch: Bug fix?           | Nope
| Minor: New feature?       | Nope
| Major: Breaking change?   | Nope
| Any dependency changes?   | Nope

<!-- Describe your changes below in as much detail as possible -->

I'm using hex_color in a different project and `random_rgb()` kept showing up in my criterion benchmarks/flamegraphs. Unsurprisingly rand::rng::Rng::gen is taking up all of the work. It's creating an u32 for each call under the hood and casting them down to a u8. 

The new approach generates a single u32 and masks different parts without any overlap to r,g,b respectively.  

My lazy benchmark seems to give a ~65% speedup.

I will not be offended if you do not merge. I would be interested to know why, if you don't. Life's for learning, and all that 😄 
